### PR TITLE
Feat: Multichain

### DIFF
--- a/dexs/SmarDex/index.ts
+++ b/dexs/SmarDex/index.ts
@@ -1,15 +1,44 @@
 import { SimpleAdapter } from "../../adapters/types";
-import { DEFAULT_DAILY_VOLUME_FIELD, DEFAULT_TOTAL_VOLUME_FIELD, getChainVolume } from "../../helpers/getUniSubgraphVolume";
+import {
+  DEFAULT_DAILY_VOLUME_FIELD,
+  DEFAULT_TOTAL_VOLUME_FIELD,
+  getGraphDimensions,
+} from "../../helpers/getUniSubgraph";
 import { CHAIN } from "../../helpers/chains";
 
-const VERSION = "v0.0.7";
+const SMARDEX_SUBGRAPH_API_KEY = process.env.SMARDEX_SUBGRAPH_API_KEY;
+const SMARDEX_SUBGRAPH_GATEWAY = "https://subgraph.smardex.io/defillama";
 
-const endpoints = {
-  [CHAIN.ETHEREUM]: `https://api.studio.thegraph.com/query/41381/smardex-volumes/${VERSION}`,
+if (!SMARDEX_SUBGRAPH_API_KEY) {
+  throw new Error("Missing SMARDEX_SUBGRAPH_API_KEY env variable");
+}
+
+const defaultHeaders = {
+  "x-api-key": SMARDEX_SUBGRAPH_API_KEY,
 };
 
-const graphs = getChainVolume({
-  graphUrls: endpoints,
+const graphUrls = {
+  [CHAIN.ARBITRUM]: `${SMARDEX_SUBGRAPH_GATEWAY}/arbitrum`,
+  [CHAIN.BSC]: `${SMARDEX_SUBGRAPH_GATEWAY}/bsc`,
+  [CHAIN.ETHEREUM]: `${SMARDEX_SUBGRAPH_GATEWAY}/ethereum`,
+  [CHAIN.POLYGON]: `${SMARDEX_SUBGRAPH_GATEWAY}/polygon`,
+};
+
+const graphRequestHeaders = {
+  [CHAIN.ARBITRUM]: defaultHeaders,
+  [CHAIN.BSC]: defaultHeaders,
+  [CHAIN.ETHEREUM]: defaultHeaders,
+  [CHAIN.POLYGON]: defaultHeaders,
+};
+
+/**
+ * @note We are using this method that allow us to use http headers
+ * The method `getGraphDimensions` try returns daily fees and total fees
+ * but we are currently not using them in our subgraphs, so they are undefined
+ */
+const graphs = getGraphDimensions({
+  graphUrls,
+  graphRequestHeaders,
   totalVolume: {
     factory: "smardexFactories",
     field: DEFAULT_TOTAL_VOLUME_FIELD,
@@ -17,7 +46,7 @@ const graphs = getChainVolume({
   dailyVolume: {
     factory: "factoryDayData",
     field: DEFAULT_DAILY_VOLUME_FIELD,
-    dateField: "date"
+    dateField: "date",
   },
 });
 
@@ -26,6 +55,18 @@ const adapter: SimpleAdapter = {
     [CHAIN.ETHEREUM]: {
       fetch: graphs(CHAIN.ETHEREUM),
       start: async () => 1678404995, // birthBlock timestamp
+    },
+    [CHAIN.BSC]: {
+      fetch: graphs(CHAIN.BSC),
+      start: async () => 1689581494,
+    },
+    [CHAIN.POLYGON]: {
+      fetch: graphs(CHAIN.POLYGON),
+      start: async () => 1689582144,
+    },
+    [CHAIN.ARBITRUM]: {
+      fetch: graphs(CHAIN.ARBITRUM),
+      start: async () => 1689582249,
     },
   },
 };

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -3,38 +3,51 @@ import volumeAdapter from "../../dexs/SmarDex";
 import { CHAIN } from "../../helpers/chains";
 import type { Adapter } from "../../adapters/types";
 
-
-const LP_FEES = 0.0005;
-const POOL_FEES = 0.0002;
-const TOTAL_FEES = LP_FEES + POOL_FEES;
-
-const baseAdapter = getDexChainFees({
-  userFees: TOTAL_FEES,
-  totalFees: TOTAL_FEES,
-  supplySideRevenue: LP_FEES,
-  revenue: POOL_FEES,
-  holdersRevenue: POOL_FEES,
-  volumeAdapter,
-});
-
-const methodology = {
-  UserFees: "0.07% of each swap is collected from the user that swaps as trading fees.",
-  Fees: "0.07% of each swap is collected from the user that swaps as trading fees.",
-  Revenue: "0.02% of each swap is collected for the staking pool (SDEX holders that staked).",
-  ProtocolRevenue: `Protocol has no revenue.`,
-  SupplySideRevenue: "0.05% of each swap is collected for the liquidity providers.",
-  HoldersRevenue: "0.02% of each swap is collected for the staking pool (SDEX holders that staked)."
-};
+// Define fees for each chain
+const FEES = {
+  [CHAIN.ETHEREUM]: { LP_FEES: 0.0005, POOL_FEES: 0.0002 },
+  [CHAIN.BSC]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
+  [CHAIN.POLYGON]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
+  [CHAIN.ARBITRUM]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
+} as { [chain: string]: { LP_FEES: number; POOL_FEES: number } };
 
 const adapter: Adapter = {
-  adapter: {
-    [CHAIN.ETHEREUM]: {
-      ...baseAdapter[CHAIN.ETHEREUM],
-      meta: {
-        methodology,
-      },
-    },
-  },
+  adapter: {},
 };
+
+for (let chain in FEES) {
+  const { LP_FEES, POOL_FEES } = FEES[chain];
+  const TOTAL_FEES = LP_FEES + POOL_FEES;
+
+  // Convert fees to percentages and round to two decimal places
+  const totalFeesPercent = (TOTAL_FEES * 100).toFixed(2);
+  const lpFeesPercent = (LP_FEES * 100).toFixed(2);
+  const poolFeesPercent = (POOL_FEES * 100).toFixed(2);
+
+  const baseAdapter = getDexChainFees({
+    userFees: TOTAL_FEES,
+    totalFees: TOTAL_FEES,
+    supplySideRevenue: LP_FEES,
+    revenue: POOL_FEES,
+    holdersRevenue: POOL_FEES,
+    volumeAdapter,
+  });
+
+  const methodology = {
+    UserFees: `${totalFeesPercent}% of each swap is collected from the user that swaps as trading fees.`,
+    Fees: `${totalFeesPercent}% of each swap is collected from the user that swaps as trading fees.`,
+    Revenue: `${poolFeesPercent}% of each swap is collected for the staking pool (SDEX holders that staked).`,
+    ProtocolRevenue: `Protocol has no revenue.`,
+    SupplySideRevenue: `${lpFeesPercent}% of each swap is collected for the liquidity providers.`,
+    HoldersRevenue: `${poolFeesPercent}% of each swap is collected for the staking pool (SDEX holders that staked).`,
+  };
+
+  adapter.adapter[chain] = {
+    ...baseAdapter[chain],
+    meta: {
+      methodology,
+    },
+  };
+}
 
 export default adapter;


### PR DESCRIPTION
This pull request makes the Dimension smardex adapter compatible with all chains supported by Smardex.
I have upgraded the staking and farming addresses on `ethereum`.

**dexs/SmarDex/index.ts** changes
- New chains added: `arbitrum`, `polygon`, and `bsc`.
- Subgraph endpoints updated to smardex subgraph gateway
- The graphql queries are authenticated with `x-api-key` header

**fees/SmarDex/index.ts** changes
- New chains added: `arbitrum`, `polygon`, and `bsc`.
- There is `0.1%` fees on the new chains
