### PR TITLE
feat: Upgradable fees implementation with the subgraphs

### DIFF
--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -33,17 +33,17 @@ const CHAIN_STARTS = {
 const FEES_METHODOLOGY = `
 A minor fee is collected on each swap, functioning as trading fees.
 The fees are set at 0.07% on Ethereum and 0.1% on other chains.
-On other networks, the fees may vary between different pairs and chains.
+On other networks, fees may vary between different pairs and chains.
 Refer to https://docs.smardex.io/overview/what-is-smardex/fees for detailed information.
 `;
 
 const methodology = {
   UserFees: FEES_METHODOLOGY,
   Fees: FEES_METHODOLOGY,
-  Revenue: `0.02% of each swap on Ethereum is collected for the staking pool (SDEX holders that staked). On the other chains, the fees are collected for the liquidity providers and fees may vary between different pairs and chains. Refer to https://docs.smardex.io/overview/what-is-smardex/fees for detailed information.`,
+  Revenue: `0.02% of each swap on Ethereum is collected for staking pool (SDEX holders that staked). On other chains, fees are collected for liquidity providers and fees may vary between different pairs and chains. Refer to https://docs.smardex.io/overview/what-is-smardex/fees for detailed information.`,
   ProtocolRevenue: `Protocol has no revenue.`,
-  SupplySideRevenue: `0.05% of each swap on Ethereum is collected for the liquidity providers. On the other chains, the fees collected for the liquidity providers and fees may vary between different pairs and chains. Refer to https://docs.smardex.io/overview/what-is-smardex/fees for detailed information.`,
-  HoldersRevenue: `0.02% of each swap on Ethereum is collected for the staking pool (SDEX holders that staked). On other chains the staking is not available and the fees are collected for buybacks SDEX and burns.`,
+  SupplySideRevenue: `0.05% of each swap on Ethereum is collected for liquidity providers. On other chains, fees collected for liquidity providers and fees may vary between different pairs and chains. Refer to https://docs.smardex.io/overview/what-is-smardex/fees for detailed information.`,
+  HoldersRevenue: `0.02% of each swap on Ethereum is collected for staking pool (SDEX holders that staked). On other chains staking is not available and fees are collected for buybacks SDEX and burns.`,
 };
 
 // Define the adapter
@@ -60,8 +60,8 @@ for (let chain in FEES) {
 /**
  * Fetch fees from the subgraph for a given timestamp and chain.
  *
- * @param time - The timestamp to fetch fees at.
- * @param chain - The blockchain chain.
+ * @param time - the timestamp to fetch fees at.
+ * @param chain - the blockchain chain.
  * @returns Promise containing fetch results.
  */
 export async function feesFromSubgraph(

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -88,13 +88,13 @@ export async function feesFromSubgraph(
   if (!fees) return { timestamp };
 
   const dailyFees = new BigNumber(fees.dailyFeesPoolUSD)
-    .plus(new BigNumber(fees.dailyFeesLPUSD))
+    .plus(new BigNumber(fees.dailyFeesLpUSD))
     .toString();
   const totalFees = new BigNumber(fees.totalFeesPoolUSD)
-    .plus(new BigNumber(fees.totalFeesLPUSD))
+    .plus(new BigNumber(fees.totalFeesLpUSD))
     .toString();
-  const dailyRevenue = new BigNumber(fees.dailyFeesLPUSD).toString();
-  const totalRevenue = new BigNumber(fees.totalFeesLPUSD).toString();
+  const dailyRevenue = new BigNumber(fees.dailyFeesLpUSD).toString();
+  const totalRevenue = new BigNumber(fees.totalFeesLpUSD).toString();
 
   return {
     timestamp,

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -74,9 +74,9 @@ export async function feesFromSubgraph(
     {
       feeDayDatas(first: 1, where: { dayId_lte: ${dayId} }) {
         dailyFeesPoolUSD
-        dailyFeesLPUSD
+        dailyFeesLpUSD
         totalFeesPoolUSD
-        totalFeesLPUSD
+        totalFeesLpUSD
       }
     }
   `;

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -40,10 +40,10 @@ Refer to https://docs.smardex.io/overview/what-is-smardex/fees for detailed info
 const methodology = {
   UserFees: FEES_METHODOLOGY,
   Fees: FEES_METHODOLOGY,
-  Revenue: `0.02% of each swap on Ethereum is collected for the staking pool (SDEX holders that staked).`,
+  Revenue: `0.02% of each swap on Ethereum is collected for the staking pool (SDEX holders that staked). On the other chains, the fees are collected for the liquidity providers and fees may vary between different pairs and chains. Refer to https://docs.smardex.io/overview/what-is-smardex/fees for detailed information.`,
   ProtocolRevenue: `Protocol has no revenue.`,
-  SupplySideRevenue: `0.05% of each swap on Ethereum is collected for the liquidity providers.`,
-  HoldersRevenue: `0.02% of each swap on Ethereum is collected for the staking pool (SDEX holders that staked).`,
+  SupplySideRevenue: `0.05% of each swap on Ethereum is collected for the liquidity providers. On the other chains, the fees collected for the liquidity providers and fees may vary between different pairs and chains. Refer to https://docs.smardex.io/overview/what-is-smardex/fees for detailed information.`,
+  HoldersRevenue: `0.02% of each swap on Ethereum is collected for the staking pool (SDEX holders that staked). On other chains the staking is not available and the fees are collected for buybacks SDEX and burns.`,
 };
 
 // Define the adapter

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -11,6 +11,20 @@ const FEES = {
   [CHAIN.ARBITRUM]: { LP_FEES: 0.0007, POOL_FEES: 0.0003 },
 } as { [chain: string]: { LP_FEES: number; POOL_FEES: number } };
 
+const poolFeesPercent = (FEES[CHAIN.ETHEREUM].POOL_FEES * 100).toFixed(2);
+const lpFeesPercent = (FEES[CHAIN.ETHEREUM].LP_FEES * 100).toFixed(2);
+
+const FEES_METHODOLOGY = `A minor fee is collected on each swap, functioning as a trading fees. The fees are set at ${
+  FEES[CHAIN.ETHEREUM]
+}% on Ethereum, and 0.1% on other chains. Please note, on these other networks, the fees can be revised and may vary between different pairs and chains. Refer to the tab marked https://docs.smardex.io/overview/what-is-smardex/fees for a comprehensive list of these details.`;
+const methodology = {
+  UserFees: FEES_METHODOLOGY,
+  Fees: FEES_METHODOLOGY,
+  Revenue: `${poolFeesPercent}% of each swap on Ethereum, is collected for the staking pool (SDEX holders that staked)`,
+  ProtocolRevenue: `Protocol has no revenue.`,
+  SupplySideRevenue: `${lpFeesPercent}% of each swap is collected for the liquidity providers.`,
+  HoldersRevenue: `${poolFeesPercent}% of each swap is collected for the staking pool (SDEX holders that staked).`,
+};
 const adapter: Adapter = {
   adapter: {},
 };
@@ -32,15 +46,6 @@ for (let chain in FEES) {
     holdersRevenue: POOL_FEES,
     volumeAdapter,
   });
-
-  const methodology = {
-    UserFees: `${totalFeesPercent}% of each swap is collected from the user that swaps as trading fees.`,
-    Fees: `${totalFeesPercent}% of each swap is collected from the user that swaps as trading fees.`,
-    Revenue: `${poolFeesPercent}% of each swap is collected for the staking pool (SDEX holders that staked).`,
-    ProtocolRevenue: `Protocol has no revenue.`,
-    SupplySideRevenue: `${lpFeesPercent}% of each swap is collected for the liquidity providers.`,
-    HoldersRevenue: `${poolFeesPercent}% of each swap is collected for the staking pool (SDEX holders that staked).`,
-  };
 
   adapter.adapter[chain] = {
     ...baseAdapter[chain],

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -61,7 +61,7 @@ for (let chain in FEES) {
  * Fetch fees from the subgraph for a given timestamp and chain.
  *
  * @param time - the timestamp to fetch fees at.
- * @param chain - the blockchain chain.
+ * @param chain - the blockchain tag.
  * @returns Promise containing fetch results.
  */
 export async function feesFromSubgraph(

--- a/fees/SmarDex/index.ts
+++ b/fees/SmarDex/index.ts
@@ -23,7 +23,7 @@ const FEES = {
 
 // SDEX contract creation timestamps for each chain
 const CHAIN_STARTS = {
-  [CHAIN.ETHEREUM]: 1593561600,
+  [CHAIN.ETHEREUM]: 1678404995,
   [CHAIN.BSC]: 1688978540,
   [CHAIN.POLYGON]: 1682085480,
   [CHAIN.ARBITRUM]: 1688976153,


### PR DESCRIPTION
Custom implementation of a the fetch method to define how to retrieve the `dailyFees`, `dailyRevenues`, `totalFees` and `totalRevenues` for a given timestamp and a given chain.

The methodology canno't be computed with the current fees (limitation on the side of defillama, I talked with the support about that). So we must define a static methodology.

The new methodology text was written by Stéphane.